### PR TITLE
Remove Must* functions and run tests in PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -132,17 +132,6 @@ returns a struct that holds on to that error and finally returns it when you cal
 like `Float(...)`. Meanwhile, it also builds up and keeps track of the path so that if any error does happen, you'll
 know exactly where to look!
 
-### But I really hate checking for errors... now what?
-
-OK, what if you're really confident the value is there, need to send it to another function, and are willing to let it
-panic if something went wrong?  That's what the `Must*` versions of all the functions that return errors are for!
-
-```go
-processScore(luna.MapFromBytes(data).Array("people").Map(0).MustFloat("score"))
-```
-
-Even with this approach, the panic will contain the same useful information you would get using the other methods.
-
 ### So what's the full interface?
 
 [Check it out](https://pkg.go.dev/github.com/mikecoop83/luna)...

--- a/all_test.go
+++ b/all_test.go
@@ -54,12 +54,6 @@ func TestArrayLen(t *testing.T) {
 	require.Equal(t, 2, l)
 }
 
-func TestArrayMustLen(t *testing.T) {
-	m := MapFromBytes(simpleJson)
-	l := m.Map("object").Array("arrayStrKey").MustLen()
-	require.Equal(t, 2, l)
-}
-
 func TestMissingArrayLen(t *testing.T) {
 	m := MapFromBytes(simpleJson)
 	notFound := m.Array("missing")
@@ -67,15 +61,6 @@ func TestMissingArrayLen(t *testing.T) {
 	l, err := notFound.Len()
 	require.Error(t, err)
 	require.Equal(t, 0, l)
-}
-
-func TestMissingArrayMustLen(t *testing.T) {
-	m := MapFromBytes(simpleJson)
-	notFound := m.Array("missing")
-	require.Error(t, notFound.Err())
-	require.Panics(t, func() {
-		notFound.MustLen()
-	})
 }
 
 func TestMissingMapError(t *testing.T) {

--- a/array.go
+++ b/array.go
@@ -87,14 +87,6 @@ func (a Array) Array(idx int) Array {
 	return Array{result, currPath, nil}
 }
 
-// MustLen returns the length of the array, or panics if there was an error
-func (a Array) MustLen() int {
-	if a.err != nil {
-		panic(a.err)
-	}
-	return len(a.a)
-}
-
 // String returns the value of a string at index `idx` in the array, or a propagated error
 func (a Array) String(idx int) (string, error) {
 	if a.err != nil {
@@ -155,18 +147,6 @@ func (a Array) Bytes() ([]byte, error) {
 	return buf, nil
 }
 
-// MustBytes returns the serialized value into a slice of bytes, or panics if there was an error
-func (a Array) MustBytes() []byte {
-	if a.err != nil {
-		panic(a.err)
-	}
-	result, err := json.Marshal(a.a)
-	if err != nil {
-		panic(err)
-	}
-	return result
-}
-
 // Inner returns the `[]interface{}` which this `Array` represents, or a propagated error
 func (a Array) Inner() ([]interface{}, error) {
 	if a.err != nil {
@@ -175,56 +155,12 @@ func (a Array) Inner() ([]interface{}, error) {
 	return a.a, nil
 }
 
-// MustInner returns the `[]interface{}` which this `Array` represents, or panics if there was an error
-func (a Array) MustInner() []interface{} {
-	if a.err != nil {
-		panic(a.err)
-	}
-	return a.a
-}
-
 // Len returns the length of the array, or a propagated error
 func (a Array) Len() (int, error) {
 	if a.err != nil {
 		return 0, a.err
 	}
 	return len(a.a), nil
-}
-
-// MustString returns the value of a string at index `idx` in the array, or panics if there was an error
-func (a Array) MustString(idx int) string {
-	if a.err != nil {
-		panic(a.err)
-	}
-	s, err := a.String(idx)
-	if err != nil {
-		panic(err)
-	}
-	return s
-}
-
-// MustFloat returns the value of a float at index `idx` in the array, or panics if there was an error
-func (a Array) MustFloat(idx int) float64 {
-	if a.err != nil {
-		panic(a.err)
-	}
-	f, err := a.Float(idx)
-	if err != nil {
-		panic(err)
-	}
-	return f
-}
-
-// MustBool returns the value of a bool at index `idx` in the array, or panics if there was an error
-func (a Array) MustBool(idx int) bool {
-	if a.err != nil {
-		panic(a.err)
-	}
-	b, err := a.Bool(idx)
-	if err != nil {
-		panic(err)
-	}
-	return b
 }
 
 // Err returns any error that was found up to this point

--- a/map.go
+++ b/map.go
@@ -49,43 +49,6 @@ func (m Map) panicOnErr() {
 	}
 }
 
-// MustHas returns true if the map contains the key `key`, or panics if there was an error
-func (m Map) MustHas(key string) bool {
-	m.panicOnErr()
-	_, ok := m.m[key]
-	return ok
-}
-
-// MustString returns the value of a string at key `key` in the map, or panics if there was an error
-func (m Map) MustString(key string) string {
-	m.panicOnErr()
-	s, err := m.String(key)
-	if err != nil {
-		panic(err)
-	}
-	return s
-}
-
-// MustFloat returns the value of a float at key `key` in the map, or panics if there was an error
-func (m Map) MustFloat(key string) float64 {
-	m.panicOnErr()
-	f, err := m.Float(key)
-	if err != nil {
-		panic(err)
-	}
-	return f
-}
-
-// MustBool returns the value of a bool at key `key` in the map, or panics if there was an error
-func (m Map) MustBool(key string) bool {
-	m.panicOnErr()
-	b, err := m.Bool(key)
-	if err != nil {
-		panic(err)
-	}
-	return b
-}
-
 // Err returns any error that was found up to this point
 func (m Map) Err() error {
 	return m.err
@@ -204,26 +167,10 @@ func (m Map) Has(key string) (bool, error) {
 	return ok, nil
 }
 
-// MustBytes returns the serialized value into a slice of bytes, or panics if there was an error
-func (m Map) MustBytes() []byte {
-	m.panicOnErr()
-	result, err := json.Marshal(m.m)
-	if err != nil {
-		panic(err)
-	}
-	return result
-}
-
-// Inner returns the `[]interface{}` which this `Array` represents, or a propagated error
+// Inner returns the `map[string]interface{}` which this `Map` represents, or a propagated error
 func (m Map) Inner() (map[string]interface{}, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
 	return m.m, nil
-}
-
-// MustInner returns the `[]interface{}` which this `Array` represents, or panics if there was an error
-func (m Map) MustInner() map[string]interface{} {
-	m.panicOnErr()
-	return m.m
 }


### PR DESCRIPTION
Since it is simple enough to create a function like `func must[T any](value T, err error) T` which can wrap any function that returns a value and error and panics if error is non-nil, removing all of the duplicated `Must*` versions of the Map and Array methods.